### PR TITLE
<refactor> : 생성일시 및 수정일시 관련 baseEntity 추가

### DIFF
--- a/src/main/java/com/partimestudy/entity/BaseEntity.java
+++ b/src/main/java/com/partimestudy/entity/BaseEntity.java
@@ -1,0 +1,32 @@
+package com.partimestudy.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@MappedSuperclass
+@SuperBuilder(builderMethodName = "doesNotUseThisBuilder")
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+
+}

--- a/src/main/java/com/partimestudy/entity/Challenge.java
+++ b/src/main/java/com/partimestudy/entity/Challenge.java
@@ -15,14 +15,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Getter
 @Setter
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
-public class Challenge {
+public class Challenge extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/partimestudy/entity/ChallengeSchedule.java
+++ b/src/main/java/com/partimestudy/entity/ChallengeSchedule.java
@@ -15,13 +15,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
 @Entity
 @Getter
 @Setter
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
-public class ChallengeSchedule {
+public class ChallengeSchedule extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/partimestudy/entity/User.java
+++ b/src/main/java/com/partimestudy/entity/User.java
@@ -12,14 +12,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Setter
 @Getter
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
-public class User {
+public class User extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/partimestudy/entity/UserChallenge.java
+++ b/src/main/java/com/partimestudy/entity/UserChallenge.java
@@ -18,13 +18,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
 @Entity
 @Getter
 @Setter
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
-public class UserChallenge {
+public class UserChallenge extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
### 1. 개요:
이 PR에는 애플리케이션 내의 엔터티에 대해 감사 가능한 타임스탬프 필드(createdAt, updatedAt, deletedAt)를 제공하는 BaseEntity 클래스가 도입되었습니다. 이 변경으로 생성, 수정, 일시 삭제 등의 엔터티 수명 주기 이벤트 추적이 향상되었습니다.

### 2. 도입된 변경 사항:

#### BaseEntity 클래스:
감사 가능한 타임스탬프가 필요한 모든 엔터티에 대한 공통 슈퍼클래스가 되도록 @MappedSuperclass 주석이 달린 새로운 BaseEntity 클래스를 추가했습니다.

#### 포함된 필드:
createdAt(LocalDateTime): 엔터티가 생성되면 자동으로 채워집니다.
updatedAt(LocalDateTime): 엔터티가 수정되면 자동으로 업데이트됩니다.
deletedAt(LocalDateTime): 소프트 삭제를 구현하도록 수동으로 설정할 수 있습니다.

BaseEntity는 다음 주석으로 구성됩니다.
생성 날짜의 자동 타임스탬프를 위한 @CreatedDate.
마지막 수정 날짜의 자동 타임스탬프를 위한 @LastModifiedDate.
Spring Data JPA 감사를 활성화하기 위한 @EntityListeners(AuditingEntityListener.class)

#### 주석 및 구성:
상용구 코드를 생성하기 위해 @NoArgsConstructor, @AllArgsConstructor, @Getter, @Setter 및 @SuperBuilder 주석이 추가되어 가독성과 유지 관리성이 향상되었습니다.
SuperBuilder 패턴은 이 클래스를 확장할 때 실수로 빌더를 사용하는 것을 방지하기 위해 맞춤 builderMethodName = "doesNotUseThisBuilder"와 함께 사용됩니다.